### PR TITLE
chore: autoload on VimEnter

### DIFF
--- a/lua/dotenv.lua
+++ b/lua/dotenv.lua
@@ -5,6 +5,7 @@ local uv = vim.loop
 local dotenv = {}
 
 dotenv.config = {
+  event = "VimEnter",
   enable_on_load = false,
   verbose = false,
 }
@@ -92,7 +93,7 @@ dotenv.setup = function(args)
 
   if dotenv.config.enable_on_load then
     local group = vim.api.nvim_create_augroup("Dotenv", { clear = true })
-    vim.api.nvim_create_autocmd("BufReadPost", { group = group, pattern = "*", callback = dotenv.autocmd })
+    vim.api.nvim_create_autocmd(dotenv.config.event, { group = group, pattern = "*", callback = dotenv.autocmd })
   end
 end
 


### PR DESCRIPTION
What do you think?

Why:
* `VimEnter` executes once
* I start with empty buffer, so `BufReadPost` is not called
* customization is nice

Drawbacks:
* notify with "ERROR" in autocmd looks ugly, but `verbose=false` solves it
  ```bash
  Error detected while processing VimEnter Autocommands for "*":
  [dotenv] .env file not found
  ```
  ![image](https://github.com/ellisonleao/dotenv.nvim/assets/2869535/b363f0b7-7d7d-4924-bab8-9dd876e3677c)
